### PR TITLE
Database Apple M1 Support

### DIFF
--- a/.docksal/docksal.env
+++ b/.docksal/docksal.env
@@ -11,7 +11,7 @@ DOCKSAL_STACK=default
 # Lock images versions for LAMP services
 # This will prevent images from being updated when Docksal is updated
 #WEB_IMAGE='docksal/web:x.x-apache2.4'
-DB_IMAGE='docksal/mysql:5.7-1.4'
+DB_IMAGE='docksal/mysql:5.7-1.6'
 #CLI_IMAGE='docksal/cli:x.x-php7.1'
 
 # Override virtual host (matches project folder name by default)


### PR DESCRIPTION
Hello,
I created a new project on my Macbook air M1 with the Docksal and this boilerplate, but I had an error about the database: 

```
 [warning] Failed to drop or create the database. Do it yourself before installing. ERROR 2005 (HY000): Unknown MySQL server host 'db' (-2)

 [notice] Starting Drupal installation. This takes a while.
 [notice] Performed install task: install_select_language
 [notice] Performed install task: install_select_profile
 [notice] Performed install task: install_load_profile

In install.core.inc line 2304:

  Database settings:

  Array


real 49.26
user 0.24
sys 0.33
```

More information from logs of the database container:
```
Running init scripts in /docker-entrypoint.d/ as root...
Including custom configuration from /var/www/.docksal/etc/mysql/my.cnf
runtime: failed to create new OS thread (have 2 already; errno=22)
fatal error: newosproc

runtime stack:
runtime.throw(0x524da0, 0x9)
	/usr/local/go/src/runtime/panic.go:527 +0x90
runtime.newosproc(0xc82002a000, 0xc820039fc0)
	/usr/local/go/src/runtime/os1_linux.go:150 +0x1ab
runtime.newm(0x555ce8, 0x0)
	/usr/local/go/src/runtime/proc1.go:1105 +0x130
runtime.main.func1()
	/usr/local/go/src/runtime/proc.go:48 +0x2c
runtime.systemstack(0x5c4300)
	/usr/local/go/src/runtime/asm_amd64.s:262 +0x79
runtime.mstart()
	/usr/local/go/src/runtime/proc1.go:674

goroutine 1 [running]:
runtime.systemstack_switch()
	/usr/local/go/src/runtime/asm_amd64.s:216 fp=0xc820024770 sp=0xc820024768
runtime.main()
	/usr/local/go/src/runtime/proc.go:49 +0x62 fp=0xc8200247c0 sp=0xc820024770
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1696 +0x1 fp=0xc8200247c8 sp=0xc8200247c0
```

I changed the version of the database and it looks like it's working.